### PR TITLE
Update dataTables.responsive.js

### DIFF
--- a/js/dataTables.responsive.js
+++ b/js/dataTables.responsive.js
@@ -627,8 +627,9 @@ Responsive.prototype = {
 			.insertBefore( dt.table().node() );
 
 		// The cloned header now contains the smallest that each column can be
+		// To be on the save side, add 20 pixels per cell.
 		dt.columns().eq(0).each( function ( idx ) {
-			columns[idx].minWidth = cells[ idx ].offsetWidth || 0;
+			columns[idx].minWidth = cells[ idx ].offsetWidth + 20 || 0;
 		} );
 
 		inserted.remove();


### PR DESCRIPTION
As mentioned in your code the calculation of the minWidth per cell is not 100% perfect. I ran in some overflow-issues with large tables ( 30+ cols). To keep the good performance and to fix this i added 20px per column. It works perfect in my case. This might be a quirky work-around, but the only bad result might be a greater cell-padding. 

In my case this fixes https://github.com/DataTables/Responsive/issues/20
